### PR TITLE
Add the possibility to tag linuxkit/kconfig with a custom tag instead…

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -271,6 +271,12 @@ endif
 
 # Target for kernel config
 kconfig:
+ifeq (${KCONFIG_TAG},)
 	docker build --no-cache -f Dockerfile.kconfig \
 		--build-arg KERNEL_VERSIONS="$(KERNEL_VERSIONS)" \
 		-t linuxkit/kconfig  .
+else
+	docker build --no-cache -f Dockerfile.kconfig \
+		--build-arg KERNEL_VERSIONS="$(KERNEL_VERSIONS)" \
+		-t linuxkit/kconfig:${KCONFIG_TAG}  .
+endif


### PR DESCRIPTION
… of latest

KCONFIG_TAG variable can be used to set a custom kconfig tag.
If KCONFIG_TAG is not set, the the image is tagged as linuxkit/kconfig:latest
This is useful for projects requiring to build multiple kernels that have
different patches.
When trying to edit an unpatched kernel config after working on a patched
kernel config (same kernel version), one had to rerun make kconfig first
in order to edit the config of an unpatched kernel.
Now it is possible to generate a tegged kconfig image and then, get the wanted
config by selecting the corresponding linuxkit/kexec:tag.

Signed-off-by: Gabriel Chabot <gabriel.chabot@qarnot-computing.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Allow to choose a custom tag to linuxkit/kconfig image when making kconfig target in kernel
**- How I did it**
Edited kernel/Makefile:
- Added an ifeq statement checking if KCONFIG_TAG is set
- If it is set, passes the option "-t linuxkit/kconfig:${KCONFIG_TAG}" to docker
- Otherwise, "-t linuxkit/kconfig" same behaviour as before
**- How to verify it**
From the repo root directory, do:
cd kernel
make KCONFIG_TAG=test kconfig
**- Description for the changelog**
Add the possibility to tag linuxkit/kconfig with a custom tag instead…
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
