### PR TITLE
Add openssl to the kernel-build

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add \
     mpc1-dev \
     mpfr-dev \
     ncurses-dev \
+    openssl \
     openssl-dev \
     patch \
     rsync \


### PR DESCRIPTION
Signed-off-by: Gabriel Chabot <gabriel.chabot@qarnot-computing.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add openssl to the kernel-build image.
It is required when building a kernel with module signing enabled.

**- How I did it**
apk add openssl with the other packages in the kernel-build image in `kernel/Dockerfile`

**- How to verify it**
Build a kernel with CONFIG_MODULE_SIG enabled in it's kconfig

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add openssl to the kernel-build


**- A picture of a cute animal (not mandatory but encouraged)**
