### PR TITLE
kernel: Add intel-ucode-with-caveats to the intel MCUs

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -76,6 +76,7 @@ RUN set -e && \
         git clone ${UCODE_REPO} ucode && \
         cd ucode && \
         git checkout ${UCODE_COMMIT} && \
+        ( [ -d intel-ucode-with-caveats ] && cp intel-ucode-with-caveats/* intel-ucode/ ) && \
         iucode_tool --normal-earlyfw --write-earlyfw=/out/intel-ucode.cpio ./intel-ucode && \
         cp license /out/intel-ucode-license.txt && \
         mkdir -p /lib/firmware && \


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add  MCUs from intel-ucode-with-caveats to the intel-ucode.cpio archive in the kernel Dockerfile

**- How I did it**
If the directory intel-ucode-with-caveats exists in the intel-ucode repository, copy the MCUs to the intel-ucode directory so they are included in the intel-ucode cpio archive

**- How to verify it**
Build a kernel and run it on a Xeon E5 v4, the microcode should be properly updated to version 0xb0003e

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add intel-ucode-with-caveats to the applied MCUs

**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: Gabriel Chabot <gabriel.chabot@qarnot-computing.com>
