### PR TITLE
Bump intel microcode version to 20220207

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -70,7 +70,7 @@ WORKDIR /tmp
 # Download Intel ucode, create a CPIO archive for it, and keep it in the build context
 # so the firmware can also be referenced with CONFIG_EXTRA_FIRMWARE
 ENV UCODE_REPO=https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files
-ENV UCODE_COMMIT=microcode-20210608
+ENV UCODE_COMMIT=microcode-20220207
 RUN set -e && \
     if [ $(uname -m) == x86_64 ]; then \
         git clone ${UCODE_REPO} ucode && \


### PR DESCRIPTION
**- What I did**

Update intel microcode

**- How I did it**

Get the latest release from github

**- How to verify it**

Build kernel and run it on affected intel CPU's

**- Description for the changelog**

Bump intel microcode version to 20220207
