### PR TITLE
kernels: Add python3 which is a dep for BPF

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -32,6 +32,7 @@ RUN apk add \
     tar \
     xz \
     xz-dev \
+    python3 \
     zlib-dev
 
 ARG KERNEL_VERSION


### PR DESCRIPTION
When building an ubuntu kernel, BPF module needs python3 to be built.